### PR TITLE
Fix #1 : Improve building and testing with Java-9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <jsr250.version>1.0</jsr250.version>
     <junit.version>4.12</junit.version>
     <logback.version>1.1.9</logback.version>
-    <mockito.version>1.9.5</mockito.version>
+    <mockito.version>2.8.9</mockito.version>
     <servlet-api.version>3.0.1</servlet-api.version>
     <slf4j.version>1.7.22</slf4j.version>
     <validation-api.version>1.1.0.Final</validation-api.version>

--- a/src/test/java/org/gbif/ws/client/filter/CreatedResponseFilterTest.java
+++ b/src/test/java/org/gbif/ws/client/filter/CreatedResponseFilterTest.java
@@ -33,43 +33,46 @@ public class CreatedResponseFilterTest {
 
   private CreatedResponseFilter filter = new CreatedResponseFilter();
   private MultivaluedMap<String, String> params;
+  private MultivaluedMap<String, Object> headers;
   private Object content;
-  @Before
-  public void setUp() {
-    params = new MultivaluedMapImpl();
-    when(mockRequest.getQueryParameters()).thenReturn(params);
-    MultivaluedMap<String, Object> headers = new StringKeyIgnoreCaseMultivaluedMap<Object>();
-    when(mockResponse.getHttpHeaders()).thenReturn(headers);
-    when(mockResponse.getMediaType()).thenReturn(MediaType.APPLICATION_JSON_TYPE);
-    when(mockResponse.getStatus()).thenReturn(200);
-    when(mockResponse.getStatusType()).thenReturn(ClientResponse.Status.OK);
-    when(mockRequest.getMethod()).thenReturn("POST");
-    content = UUID.randomUUID();
-    when(mockResponse.getEntity()).thenReturn(content);
-    when(mockRequest.getRequestUriBuilder()).thenReturn(UriBuilder.fromUri("http://api.gbif.org/node"));
-  }
-
+  
   @Mock
   ContainerResponse mockResponse;
 
   @Mock
   ContainerRequest mockRequest;
 
+  @Before
+  public void setUp() {
+    params = new MultivaluedMapImpl();
+    headers = new StringKeyIgnoreCaseMultivaluedMap<Object>();
+    content = UUID.randomUUID();
+  }
+
   @Test
   public void testEmptyEntity() {
+    when(mockResponse.getHttpHeaders()).thenReturn(headers);
+    when(mockResponse.getStatusType()).thenReturn(ClientResponse.Status.OK);
+    when(mockRequest.getMethod()).thenReturn("POST");
+    when(mockResponse.getEntity()).thenReturn(content);
     setContent(null);
     assertNoLocationHeader(filter.filter(mockRequest, mockResponse));
   }
 
   @Test
   public void testWrongMethod() {
+    when(mockResponse.getHttpHeaders()).thenReturn(headers);
     when(mockRequest.getMethod()).thenReturn("PUT");
+    when(mockResponse.getEntity()).thenReturn(content);
     assertNoLocationHeader(filter.filter(mockRequest, mockResponse));
   }
 
   @Test
   public void testWrongReturnType() {
+    when(mockResponse.getHttpHeaders()).thenReturn(headers);
+    when(mockResponse.getStatusType()).thenReturn(ClientResponse.Status.OK);
     when(mockRequest.getMethod()).thenReturn("POST");
+    when(mockResponse.getEntity()).thenReturn(content);
     Map<String, Integer > data = Maps.newHashMap();
     data.put("feel", 17);
     data.put("act", 21);
@@ -87,6 +90,11 @@ public class CreatedResponseFilterTest {
 
   @Test
   public void testSuccessfulPost() {
+    when(mockResponse.getHttpHeaders()).thenReturn(headers);
+    when(mockResponse.getStatusType()).thenReturn(ClientResponse.Status.OK);
+    when(mockRequest.getMethod()).thenReturn("POST");
+    when(mockResponse.getEntity()).thenReturn(content);
+    when(mockRequest.getRequestUriBuilder()).thenReturn(UriBuilder.fromUri("http://api.gbif.org/node"));
     content = UUID.randomUUID();
     when(mockResponse.getEntity()).thenReturn(content);
 

--- a/src/test/java/org/gbif/ws/client/filter/CreatedResponseFilterTest.java
+++ b/src/test/java/org/gbif/ws/client/filter/CreatedResponseFilterTest.java
@@ -18,7 +18,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;

--- a/src/test/java/org/gbif/ws/client/filter/HttpGbifAuthFilterTest.java
+++ b/src/test/java/org/gbif/ws/client/filter/HttpGbifAuthFilterTest.java
@@ -38,16 +38,10 @@ public class HttpGbifAuthFilterTest {
   ArgumentCaptor<ClientRequestAdapter> captor = ArgumentCaptor.forClass(ClientRequestAdapter.class);
 
   @Before
-  public void setupMock() throws URISyntaxException {
+  public void setUp() throws URISyntaxException {
     headers = new OutBoundHeaders();
     entity = "Simsalabim";
     uri = new URI("http://localhost/dataset");
-    when(mockRequest.getURI()).thenReturn(uri);
-    when(mockRequest.getMethod()).thenReturn("POST");
-    when(mockRequest.getEntity()).thenReturn(entity);
-    // we instantiate a real request here, because there is no implementation of MultivaluedMap<String, Object>
-    when(mockRequest.getHeaders()).thenReturn(headers);
-    when(mockRequest.getAdapter()).thenReturn(origAdapter);
   }
 
   @Test
@@ -75,6 +69,12 @@ public class HttpGbifAuthFilterTest {
 
   @Test
   public void testHandleWithPrincipal() throws Exception {
+    when(mockRequest.getURI()).thenReturn(uri);
+    when(mockRequest.getMethod()).thenReturn("POST");
+    when(mockRequest.getEntity()).thenReturn(entity);
+    // we instantiate a real request here, because there is no implementation of MultivaluedMap<String, Object>
+    when(mockRequest.getHeaders()).thenReturn(headers);
+
     pp.setPrincipal("Søren");
 
     execute();

--- a/src/test/java/org/gbif/ws/client/filter/HttpGbifAuthFilterTest.java
+++ b/src/test/java/org/gbif/ws/client/filter/HttpGbifAuthFilterTest.java
@@ -15,7 +15,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;

--- a/src/test/java/org/gbif/ws/client/filter/JsonpResponseFilterTest.java
+++ b/src/test/java/org/gbif/ws/client/filter/JsonpResponseFilterTest.java
@@ -16,7 +16,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -80,7 +80,6 @@ public class JsonpResponseFilterTest {
   @Test
   public void testEmptyAndMissingCallback() {
     when(mockResponse.getMediaType()).thenReturn(MediaType.APPLICATION_JSON_TYPE);
-    when(mockResponse.getEntity()).thenReturn("{id:1}");
 
     assertEquals(mockResponse, filter.filter(mockRequest, mockResponse));
     verify(mockResponse, never()).setEntity(any());

--- a/src/test/java/org/gbif/ws/security/GbifAuthServiceTest.java
+++ b/src/test/java/org/gbif/ws/security/GbifAuthServiceTest.java
@@ -18,7 +18,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.gbif.ws.security.GbifAuthService.HEADER_AUTHORIZATION;
 import static org.gbif.ws.security.GbifAuthService.HEADER_CONTENT_MD5;
@@ -49,6 +49,8 @@ public class GbifAuthServiceTest {
   @Mock
   ClientRequest mockRequest;
   MultivaluedMap<String, Object> headers;
+  
+  private URI testUri;
 
   private static class HeaderWrapper implements MultivaluedMap<String, String> {
 
@@ -143,11 +145,33 @@ public class GbifAuthServiceTest {
   }
 
   @Before
-  public void initMocks() throws Exception {
-    URI uri = new URI("http://api.gbif.org/v1/dataset");
-    when(mockRequest.getURI()).thenReturn(uri);
-    when(containerRequest.getRequestUri()).thenReturn(uri);
-    when(containerRequest.getAbsolutePath()).thenReturn(uri);
+  public void setUp() throws Exception {
+    testUri = new URI("http://api.gbif.org/v1/dataset");
+  }
+
+  @Test
+  public void testSignRequest() throws Exception {
+    when(mockRequest.getURI()).thenReturn(testUri);
+
+    when(mockRequest.getMethod()).thenReturn("POST");
+
+    Object entity = "Simsalabim";
+    when(mockRequest.getEntity()).thenReturn(entity);
+    // we instantiate a real request here, because there is no implementation of MultivaluedMap<String, Object>
+    headers = new OutBoundHeaders();
+    when(mockRequest.getHeaders()).thenReturn(headers);
+	  
+    GbifAuthService service = GbifAuthService.singleKeyAuthService(APPKEY, APPSECRET);
+    service.signRequest("heinz", mockRequest);
+
+    assertNotNull(headers.getFirst(HEADER_CONTENT_MD5));
+    assertEquals("heinz", headers.getFirst(HEADER_GBIF_USER));
+    assertTrue(headers.getFirst(HEADER_AUTHORIZATION).toString().startsWith("GBIF appKey:"));
+  }
+
+  @Test
+  public void testIsValid() throws Exception {
+    when(mockRequest.getURI()).thenReturn(testUri);
 
     when(mockRequest.getMethod()).thenReturn("POST");
     when(containerRequest.getMethod()).thenReturn("POST");
@@ -159,25 +183,6 @@ public class GbifAuthServiceTest {
     when(mockRequest.getHeaders()).thenReturn(headers);
     when(containerRequest.getRequestHeaders()).thenReturn(new HeaderWrapper(headers));
     when(containerRequest.getHeaderValue(eq(HEADER_AUTHORIZATION))).thenCallRealMethod();
-    when(containerRequest.getHeaderValue(eq(HEADER_CONTENT_TYPE))).thenCallRealMethod();
-    when(containerRequest.getHeaderValue(eq(HEADER_CONTENT_MD5))).thenCallRealMethod();
-    when(containerRequest.getHeaderValue(eq(HEADER_GBIF_USER))).thenCallRealMethod();
-
-  }
-
-  @Test
-  public void testSignRequest() throws Exception {
-
-    GbifAuthService service = GbifAuthService.singleKeyAuthService(APPKEY, APPSECRET);
-    service.signRequest("heinz", mockRequest);
-
-    assertNotNull(headers.getFirst(HEADER_CONTENT_MD5));
-    assertEquals("heinz", headers.getFirst(HEADER_GBIF_USER));
-    assertTrue(headers.getFirst(HEADER_AUTHORIZATION).toString().startsWith("GBIF appKey:"));
-  }
-
-  @Test
-  public void testIsValid() throws Exception {
 
     GbifAuthService service = GbifAuthService.singleKeyAuthService(APPKEY, APPSECRET);
 

--- a/src/test/java/org/gbif/ws/server/filter/AuthFilterTest.java
+++ b/src/test/java/org/gbif/ws/server/filter/AuthFilterTest.java
@@ -20,9 +20,9 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Matchers;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -70,22 +70,14 @@ public class AuthFilterTest {
   }
 
   @Before
-  public void initMocks() {
-    when(userService.get(Matchers.<String>eq("admin"))).thenReturn(admin);
-    when(userService.authenticate(Matchers.<String>eq("admin"), Matchers.<String>any())).thenReturn(admin);
-    when(userService.get(Matchers.<String>eq("heinz"))).thenReturn(heinz);
-    when(userService.authenticate(Matchers.<String>eq("heinz"), Matchers.<String>any())).thenReturn(heinz);
-    // setup basic POST request
-    when(mockRequest.getQueryParameters()).thenReturn(new MultivaluedMapImpl());
-    when(mockRequest.getMethod()).thenReturn("POST");
-    setMockAuth(null);
-
+  public void setUp() {
     GbifAuthService authService = GbifAuthService.multiKeyAuthService(GbifAuthServiceTest.buildAppKeyMap());
     filter = new AuthFilter(userService, authService);
   }
 
   @Test
   public void testFilterWithAnonymous() throws Exception {
+    setMockAuth(null);
     assertPrincipalName(null);
 
     setMockAuth("");
@@ -103,6 +95,7 @@ public class AuthFilterTest {
 
   @Test
   public void testFilterWithBasicHeinz() throws Exception {
+    when(userService.authenticate(ArgumentMatchers.<String>eq("heinz"), ArgumentMatchers.<String>any())).thenReturn(heinz);
     setMockAuth(heinzAuthBasic);
     assertPrincipalName("heinz");
   }
@@ -117,7 +110,7 @@ public class AuthFilterTest {
 
   @Test
   public void testFilterWithGET() throws Exception {
-    when(mockRequest.getMethod()).thenReturn("GET");
+    setMockAuth(null);
     assertPrincipalName(null);
   }
 
@@ -155,7 +148,7 @@ public class AuthFilterTest {
   }
 
   private void setMockAuth(String authentication) {
-    when(mockRequest.getHeaderValue(Matchers.<String>eq(ContainerRequest.AUTHORIZATION))).thenReturn(authentication);
+    when(mockRequest.getHeaderValue(ArgumentMatchers.<String>eq(ContainerRequest.AUTHORIZATION))).thenReturn(authentication);
   }
 
 }


### PR DESCRIPTION
This Pull Requests migrates the Mockito tests to version 2, where unused mocks are forbidden.

It still has test issues with Google Guice. Those issues are possibly related to how Guice shades/repackages cglib internally and have not released an update with a Java 9 compatible version of cglib, so Guice is broken for Java 9 at this point:

https://github.com/google/guice/issues/1085

The stacktrace for the Guice failure is:

```
[INFO] Running org.gbif.ws.client.guice.GbifWsClientModuleTest
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.511 s <<< FAILURE! - in org.gbif.ws.client.guice.GbifWsClientModuleTest
[ERROR] org.gbif.ws.client.guice.GbifWsClientModuleTest  Time elapsed: 0.511 s  <<< ERROR!
java.lang.ExceptionInInitializerError
	at com.google.inject.internal.cglib.reflect.$FastClassEmitter.<init>(FastClassEmitter.java:67)
	at com.google.inject.internal.cglib.reflect.$FastClass$Generator.generateClass(FastClass.java:72)
	at com.google.inject.internal.cglib.core.$DefaultGeneratorStrategy.generate(DefaultGeneratorStrategy.java:25)
	at com.google.inject.internal.cglib.core.$AbstractClassGenerator.create(AbstractClassGenerator.java:216)
	at com.google.inject.internal.cglib.reflect.$FastClass$Generator.create(FastClass.java:64)
	at com.google.inject.internal.BytecodeGen.newFastClass(BytecodeGen.java:204)
	at com.google.inject.internal.ProviderMethod$FastClassProviderMethod.<init>(ProviderMethod.java:256)
	at com.google.inject.internal.ProviderMethod.create(ProviderMethod.java:71)
	at com.google.inject.internal.ProviderMethodsModule.createProviderMethod(ProviderMethodsModule.java:275)
	at com.google.inject.internal.ProviderMethodsModule.getProviderMethods(ProviderMethodsModule.java:144)
	at com.google.inject.internal.ProviderMethodsModule.configure(ProviderMethodsModule.java:123)
	at com.google.inject.spi.Elements$RecordingBinder.install(Elements.java:340)
	at com.google.inject.spi.Elements$RecordingBinder.install(Elements.java:349)
	at com.google.inject.spi.Elements.getElements(Elements.java:110)
	at com.google.inject.internal.InjectorShell$Builder.build(InjectorShell.java:138)
	at com.google.inject.internal.InternalInjectorCreator.build(InternalInjectorCreator.java:104)
	at com.google.inject.Guice.createInjector(Guice.java:96)
	at com.google.inject.Guice.createInjector(Guice.java:73)
	at com.google.inject.Guice.createInjector(Guice.java:62)
	at org.gbif.ws.client.guice.GbifWsClientModuleTest.initInjector(GbifWsClientModuleTest.java:31)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:563)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:24)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:365)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:272)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:236)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:159)
	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:386)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:323)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:143)
Caused by: java.lang.reflect.InaccessibleObjectException: Unable to make protected final java.lang.Class java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int,java.security.ProtectionDomain) throws java.lang.ClassFormatError accessible: module java.base does not "opens java.lang" to unnamed module @f627d13
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:337)
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:281)
	at java.base/java.lang.reflect.Method.checkCanSetAccessible(Method.java:197)
	at java.base/java.lang.reflect.Method.setAccessible(Method.java:191)
	at com.google.inject.internal.cglib.core.$ReflectUtils$2.run(ReflectUtils.java:56)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at com.google.inject.internal.cglib.core.$ReflectUtils.<clinit>(ReflectUtils.java:46)
	... 36 more
```